### PR TITLE
Remove unused Epics, Releases, and Sprints routes

### DIFF
--- a/kavindra-api/src/app/app.module.ts
+++ b/kavindra-api/src/app/app.module.ts
@@ -8,12 +8,9 @@ import {ThrottlerGuard, ThrottlerModule} from '@nestjs/throttler';
 import {routes} from './app.routes';
 import {ClientsModule} from './clients/clients.module';
 import {EmbedScriptsModule} from './embed-scripts/embed-scripts.module';
-import {EpicsModule} from './epics/epics.module';
 import {IssuesModule} from './issues/issues.module';
 import {PaymentsModule} from './payments/payments.module';
 import {ProjectsModule} from './projects/projects.module';
-import {ReleasesModule} from './releases/releases.module';
-import {SprintsModule} from './sprints/sprints.module';
 import {UsersModule} from './users/users.module';
 import {AuthModule} from '../lib/auth/auth.module';
 import {SupabaseAuthGuard} from '../lib/auth/supabase/guards/supabase-auth/supabase-auth.guard';
@@ -36,10 +33,7 @@ import {SupabaseAuthGuard} from '../lib/auth/supabase/guards/supabase-auth/supab
     }),
     AuthModule,
     IssuesModule,
-    ReleasesModule,
     ClientsModule,
-    EpicsModule,
-    SprintsModule,
     UsersModule,
     ProjectsModule,
     PaymentsModule,

--- a/kavindra-api/src/app/app.routes.ts
+++ b/kavindra-api/src/app/app.routes.ts
@@ -2,12 +2,9 @@ import {Routes} from '@nestjs/core';
 
 import {ClientsModule} from './clients/clients.module';
 import {EmbedScriptsModule} from './embed-scripts/embed-scripts.module';
-import {EpicsModule} from './epics/epics.module';
 import {IssuesModule} from './issues/issues.module';
 import {PaymentsModule} from './payments/payments.module';
 import {ProjectsModule} from './projects/projects.module';
-import {ReleasesModule} from './releases/releases.module';
-import {SprintsModule} from './sprints/sprints.module';
 import {UsersModule} from './users/users.module';
 
 export const routes: Routes = [
@@ -26,18 +23,6 @@ export const routes: Routes = [
   {
     path: 'issues',
     module: IssuesModule,
-  },
-  {
-    path: 'epics',
-    module: EpicsModule,
-  },
-  {
-    path: 'releases',
-    module: ReleasesModule,
-  },
-  {
-    path: 'sprints',
-    module: SprintsModule,
   },
   {
     path: 'projects',

--- a/kavindra-api/src/app/epics/epics.module.ts
+++ b/kavindra-api/src/app/epics/epics.module.ts
@@ -1,4 +1,0 @@
-import {Module} from '@nestjs/common';
-
-@Module({})
-export class EpicsModule {}

--- a/kavindra-api/src/app/releases/releases.module.ts
+++ b/kavindra-api/src/app/releases/releases.module.ts
@@ -1,4 +1,0 @@
-import {Module} from '@nestjs/common';
-
-@Module({})
-export class ReleasesModule {}

--- a/kavindra-api/src/app/sprints/sprints.module.ts
+++ b/kavindra-api/src/app/sprints/sprints.module.ts
@@ -1,4 +1,0 @@
-import {Module} from '@nestjs/common';
-
-@Module({})
-export class SprintsModule {}


### PR DESCRIPTION
This PR removes redundant routes and associated module imports, simplifying the app's routing configuration for better maintainability and reduced code clutter.